### PR TITLE
Secure password storage using hashing

### DIFF
--- a/admin/admins.php
+++ b/admin/admins.php
@@ -1,0 +1,17 @@
+<?php
+$pdo = new PDO('mysql:host=localhost;dbname=app', 'user', 'pass');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+
+    if (!empty($_POST['id'])) {
+        $stmt = $pdo->prepare('UPDATE admins SET username = ?, password = ? WHERE id = ?');
+        $stmt->execute([$username, $hashedPassword, $_POST['id']]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO admins (username, password) VALUES (?, ?)');
+        $stmt->execute([$username, $hashedPassword]);
+    }
+}
+?>

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,0 +1,17 @@
+<?php
+$pdo = new PDO('mysql:host=localhost;dbname=app', 'user', 'pass');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+
+    if (!empty($_POST['id'])) {
+        $stmt = $pdo->prepare('UPDATE users SET username = ?, password = ? WHERE id = ?');
+        $stmt->execute([$username, $hashedPassword, $_POST['id']]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+        $stmt->execute([$username, $hashedPassword]);
+    }
+}
+?>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,22 @@
+<?php
+session_start();
+
+$pdo = new PDO('mysql:host=localhost;dbname=app', 'user', 'pass');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    $stmt = $pdo->prepare('SELECT id, password FROM users WHERE username = ?');
+    $stmt->execute([$username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        header('Location: dashboard.html');
+        exit;
+    }
+
+    $error = 'Invalid credentials';
+}
+?>

--- a/scripts/rehash_passwords.php
+++ b/scripts/rehash_passwords.php
@@ -1,0 +1,18 @@
+<?php
+// One-time script to migrate plaintext passwords to hashed values.
+$pdo = new PDO('mysql:host=localhost;dbname=app', 'user', 'pass');
+
+foreach (['users', 'admins'] as $table) {
+    $stmt = $pdo->query("SELECT id, password FROM {$table}");
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $info = password_get_info($row['password']);
+        if ($info['algo'] === 0) { // Not hashed
+            $hashed = password_hash($row['password'], PASSWORD_DEFAULT);
+            $update = $pdo->prepare("UPDATE {$table} SET password = ? WHERE id = ?");
+            $update->execute([$hashed, $row['id']]);
+        }
+    }
+}
+
+echo "Password rehash complete.\n";
+?>

--- a/user/profile.php
+++ b/user/profile.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+$pdo = new PDO('mysql:host=localhost;dbname=app', 'user', 'pass');
+
+$userId = $_SESSION['user_id'] ?? null;
+if (!$userId) {
+    exit('Unauthorized');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $password = $_POST['password'] ?? '';
+    if ($password !== '') {
+        $hashedPassword = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('UPDATE users SET password = ? WHERE id = ?');
+        $stmt->execute([$hashedPassword, $userId]);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- authenticate users with `password_verify`
- hash new or updated passwords via `password_hash`
- provide script to migrate plaintext passwords to hashed values

## Testing
- `php -l login.php admin/admins.php admin/users.php user/profile.php scripts/rehash_passwords.php`


------
https://chatgpt.com/codex/tasks/task_e_68aa6804cba88332b5c7a30690d5c021